### PR TITLE
Updates for Using Python Page

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,0 +1,2 @@
+---
+BUNDLE_PATH: "vendor/bundle"

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 /.jekyll-metadata
 /.jekyll-cache/
 .DS_Store
+
+# locally installed bundler files
+vendor/

--- a/_pages/Using_the_Micro-Manager_python_library.md
+++ b/_pages/Using_the_Micro-Manager_python_library.md
@@ -6,15 +6,29 @@ layout: page
 section: Extend
 ---
 
-The easiest way to control Micro-Manager through Python is the
-[Pycro-manager](https://github.com/micro-manager/pycro-manager) library.
+There are three main Python libraries for interfaces with microscopes
+through Micro-Manager/micr
+
+1. [pymmcore](https://github.com/micro-manager/pymmcore#pymmcore-python-bindings-for-mmcore)
+    provides a Python bindings of the underlying C++ library
+    [mmCoreAndDevices](https://github.com/micro-manager/mmCoreAndDevices#mmcoreanddevices) that
+    Micro-Manager uses. This option does not require you to launch Micro-Manager, or
+    even to have Java installed. However, it does not come with a GUI. If you want a GUI
+    that integrates with pymmcore you can use the community developed
+    [napari-micromanager](https://github.com/tlambert03/napari-micromanager#napari-micromanager).
+    - [pymmcore-plus](https://github.com/tlambert03/pymmcore-plus#pymmcore-plus) is a thin wrapper
+      of `pymmcore` that extends the core object, adding additional methods, docstrings, type hints,
+      as well as better support for integration into a GUI event loop.
+2. [Pycro-manager](https://github.com/micro-manager/pycro-manager) provides a bridge between Python
+   and the Micro-Manager java runtime. This not only allows you to continue to use the Micro-Manager
+   GUI in parallel with Python scripting it also gives you access to leverage existing Micro-Manager
+   plugins.
+3. **MMCorePy** was formerlly included in Micro-Manager. It has been deprecated and superceded by
+  `pymmcore`.
 
 The instructions below are for an alternative mechanism in which you
 compile the micro-manager core yourself with python bindings.
 
-**MMCorePy** is a wrapper that allows you to control microscope hardware
-from python interactive session or script. It's support Windows, Mac and
-Linux.
 
 Micromanager's main parts:
 
@@ -24,9 +38,6 @@ Micromanager's main parts:
     hardware. If you want to built one and extend MM devise support,
     follow [this
     guide](Building_Micro-Manager_Device_Adapters).
--   MMCorePy - python wrapper. MM build scripts are support both python
-    2 and 3, but windows version still ships with python 2 bindings
-    only.
 -   MMCoreJ - java wrapper
 -   MMStudio - Micromanager GUI (technically it is ImageJ plugin).
 

--- a/_pages/Using_the_Micro-Manager_python_library.md
+++ b/_pages/Using_the_Micro-Manager_python_library.md
@@ -20,7 +20,7 @@ through Micro-Manager/micr
     even to have Java installed. However, it does not come with a GUI. If you want a GUI
     that integrates with pymmcore you can use the community developed
     [napari-micromanager](https://github.com/tlambert03/napari-micromanager#napari-micromanager).
-    - [pymmcore-plus](https://github.com/tlambert03/pymmcore-plus#pymmcore-plus) is a thin wrapper
+    - [pymmcore-plus](https://pymmcore-plus.readthedocs.io/) is a thin wrapper
       of `pymmcore` that extends the core object, adding additional methods, docstrings, type hints,
       as well as better support for integration into a GUI event loop.
     - `MMCorePy` was formerly included in Micro-Manager. It has been deprecated and superceded by `pymmcore`.

--- a/_pages/Using_the_Micro-Manager_python_library.md
+++ b/_pages/Using_the_Micro-Manager_python_library.md
@@ -9,7 +9,11 @@ section: Extend
 There are three main Python libraries for interfaces with microscopes
 through Micro-Manager/micr
 
-1. [pymmcore](https://github.com/micro-manager/pymmcore#pymmcore-python-bindings-for-mmcore)
+1. [Pycro-manager](https://github.com/micro-manager/pycro-manager) provides a bridge between Python
+   and the Micro-Manager java runtime. This not only allows you to continue to use the Micro-Manager
+   GUI in parallel with Python scripting it also gives you access to leverage existing Micro-Manager
+   plugins.
+2. [pymmcore](https://github.com/micro-manager/pymmcore#pymmcore-python-bindings-for-mmcore)
     provides a Python bindings of the underlying C++ library
     [mmCoreAndDevices](https://github.com/micro-manager/mmCoreAndDevices#mmcoreanddevices) that
     Micro-Manager uses. This option does not require you to launch Micro-Manager, or
@@ -19,12 +23,8 @@ through Micro-Manager/micr
     - [pymmcore-plus](https://github.com/tlambert03/pymmcore-plus#pymmcore-plus) is a thin wrapper
       of `pymmcore` that extends the core object, adding additional methods, docstrings, type hints,
       as well as better support for integration into a GUI event loop.
-2. [Pycro-manager](https://github.com/micro-manager/pycro-manager) provides a bridge between Python
-   and the Micro-Manager java runtime. This not only allows you to continue to use the Micro-Manager
-   GUI in parallel with Python scripting it also gives you access to leverage existing Micro-Manager
-   plugins.
-3. **MMCorePy** was formerlly included in Micro-Manager. It has been deprecated and superceded by
-  `pymmcore`.
+    - `MMCorePy` was formerly included in Micro-Manager. It has been deprecated and superceded by `pymmcore`.
+
 
 The instructions below are for an alternative mechanism in which you
 compile the micro-manager core yourself with python bindings.
@@ -50,6 +50,12 @@ the downloads [here](https://github.com/conda-forge/miniforge#mambaforge).
 ```
 conda create -n micro -c conda-forge python matplotlib pymmcore
 conda activate micro
+```
+
+alternatively you can install using pip:
+
+```
+pip install pymmcore #or pip install pymmcore-plus
 ```
 
 
@@ -103,7 +109,7 @@ capabilities." %}
 Install `pymmcore`:
 
 ```bash
-pip install pymmcore
+pip install pymmcore # or pip install pymmcore-plus
 ```
 
 Start python interactive session. Import \`pymmcore\` and make sure
@@ -114,6 +120,12 @@ import pymmcore
 mmc = pymmcore.CMMCore()  # Instance micromanager core
 mmc.getVersionInfo() # gives: 'MMCore version 2.3.2'
 mmc.getAPIVersionInfo() # gives: 'Device API version 59, Module API version 10'
+```
+For this tutorial you may also use `pymmcore-plus`. To do this replace the first two lines with:
+
+```python
+import pymmcore_plus
+mmc = pymmcore_plus.CMMCore.instance()  # Instance micromanager core
 ```
 
 We just get some basic information about current Micromanager


### PR DESCRIPTION
Two main commits to look at here:

1. https://github.com/micro-manager/micro-manager.github.io/commit/aac416c1227802ae234c12c446a345428759f797
Updates the description of available libraries following the thoughts  in #90. In particular would be good to get input from: 
 @fdrgsp, @tlambert03 and @henrypinkard (and maybe @oeway has a library to add here?)


2. https://github.com/micro-manager/micro-manager.github.io/commit/debee6d5917abdac9d8c867898989b458afd33d9
Updates the MMCorePy tutorial to use pymmcore. I also refreshed or expanded on good chunk (but not all) of the content. I guess @marktsuchida would be a good person to look at this commit.


finally https://github.com/micro-manager/micro-manager.github.io/commit/e2478d5ce0049d21a6bf78d499c64cf5b01a9823 just makes it nicer to run the jekyll docs locally.