### PR TITLE
Add minimal page for experimental PyDevice

### DIFF
--- a/_pages/Device_Support.md
+++ b/_pages/Device_Support.md
@@ -439,6 +439,7 @@ release](Download_Micro-Manager_Latest_Release).
     Controllers (USB-connected)
 -   [pgFocus](pgFocus) - Open Software/Hardware Focus
     Stabilization from [BIG](http://big.umassmed.edu)
+-   [PyDevice](PyDevice) (Experimental) - Devices controlled by Python scripts
 -   [Rapp](Rapp) - Rapp UGA40 photobleaching/photoactivation
     unit
 -   [SimpleAutofocus](SimpleAutofocus) - Image-based

--- a/_pages/PyDevice.md
+++ b/_pages/PyDevice.md
@@ -1,0 +1,17 @@
+---
+title: PyDevice (Experimental)
+layout: page
+---
+
+| Summary | Experimental: devices controlled by Python scripts |
+| Author  | Ivo Vellekoop and Jeroen Doornbos |
+| License | BSD |
+| Platforms | Currently Windows only |
+
+---
+
+{% include notice icon="warning" content="PyDevice is experimental. Python
+scripts and hardware configuration files using PyDevice will break without
+notice as we evolve the design. Use at your own risk." %}
+
+For current documentation, see the Markdown documentation files in the [source tree](https://github.com/micro-manager/mmCoreAndDevices/tree/main/DeviceAdapters/PyDevice).


### PR DESCRIPTION
As proposed in discussion for https://github.com/micro-manager/mmCoreAndDevices/pull/414.

This to be merged only when PyDevice is merged.

Cc: @IvoVellekoop, @JeroenDoornbos, @tlambert03, @henrypinkard; comments and bikeshedding welcome.