### PR TITLE
Update ObjectiveImaging.md

### DIFF
--- a/_pages/ObjectiveImaging.md
+++ b/_pages/ObjectiveImaging.md
@@ -35,7 +35,7 @@ Don Laferty, 4/9/12
 <tr>
 <td markdown="1">
 
-**Maintenainer:**
+**Maintainer:**
 
 </td>
 <td markdown="1">
@@ -85,6 +85,14 @@ Windows
 Requires the [OASIS
 Software](http://www.objectiveimaging.com/download/software.php) package
 from Objective Imaging.
+
+Here is the direct link to
+[OASIS V511 (6b)](http://objectiveimaging.com/download/files/OASIS_V511_(6b).zip)
+with drivers compatible with Windows 10.
+
+If the zip package is not available from Objective Imaging anymore, it
+may still be available from
+[archive.org](https://web.archive.org/web/20220208040412/http://objectiveimaging.com/download/files/OASIS_V511_(6b).zip).
 
 
 ## Objective Imaging OASIS-4i / OASIS-Blue controller board


### PR DESCRIPTION
The zip package seems only to be accessible as a direct link these days. There is a backup download on archive.org. This update links to both so if you find one of these cards (they are very good), you might still be able to use it with Windows 10.

The zip also contains a newer SDK than the one provided in 3rdpartypublic, and I was able to compile the MM device adapter with it.

Having said that, my Oasis 4i card has seen better days and I'm having a bit of trouble both with the oasis configuration software and the MM adapter install.

When I get it all to work again, I'll do a pull request for the device adapter as well.

Cheers,
Egor