### PR TITLE
add step to compile libraries before plugins

### DIFF
--- a/_pages/Building_MM_on_Windows.md
+++ b/_pages/Building_MM_on_Windows.md
@@ -226,6 +226,7 @@ script):
  MMCoreJ_wrap\build.xml
  mmstudio\build.xml
  acqEngine\build.xml
+ librariers\build.xml
  plugins\*\build.xml
  autofocus\build.xml
 ```


### PR DESCRIPTION
plugins depend on libraries being compiled; unless you run `ant jar` in libraries folder, you can't run `ant jar` for some plugins