### PR TITLE
Update instructions to use VS2022 toolset (v143)

### DIFF
--- a/_pages/Building_MM_on_Windows.md
+++ b/_pages/Building_MM_on_Windows.md
@@ -25,16 +25,11 @@ You need to install the following:
 
 - Visual Studio Community 2022, with the `Desktop development with C++`
   workload, plus
-  - `MSVC v142 - VS 2019 C++ x64/x86 build tools`,
-  - `Windows 10 SDK 10.0.19041`, and
-  - `Windows 10 SDK 10.0.20348`
+  - `MSVC v142 - VS 2019 C++ x64/x86 build tools` (now optional; only needed
+    for work on some outstanding pull requests)
 
-The checkbox for the MSVC v142 build tools and the Windows 10 SDKs is located
-under `Desktop development with C++` in the right sidebar titled "Installation
-details".
-
-(Both versions of the Windows 10 SDK are actually needed for all parts of the
-build to work correctly.)
+The checkbox for the MSVC v142 build tools is located under `Desktop development
+with C++` in the right sidebar titled "Installation details".
 
 ### Java Development Kit (JDK) 8
 

--- a/_pages/Visual_Studio_project_settings_for_device_adapters.md
+++ b/_pages/Visual_Studio_project_settings_for_device_adapters.md
@@ -85,8 +85,8 @@ Studio. The following assumes that those instructions were followed.
     Release), so choose **All Configurations** from the
     **Configuration:** popup menu (make sure you do this again if you
     close and reopen the **Property Pages**).
-17. Under **Configuration Properties &gt; General**, set **Platform
-    Toolset** to **Visual Studio 2019 (v142)**.
+17. Under **Configuration Properties &gt; General**, make sure **Platform
+    Toolset** is set to **Visual Studio 2022 (v143)**.
 18. Under **Configuration Properties &gt; C/C++ &gt; General**, set
     **Warning Level** to **inherit from parent or project defaults**
     (which should display **Level4** after clicking **Apply**).
@@ -133,8 +133,7 @@ sure your project does not override the defaults.
     
 **Windows SDK Version**: 10.0 (latest installed version).
 
-**Platform Toolset**: Currently must be **Visual Studio 2019 (v142)**
-(even if you are using Visual Studio 2022).
+**Platform Toolset**: Currently we use **Visual Studio 2022 (v143)**.
     
 **C++ Language Standard**: Default (ISO C++ 14 Standard).
 


### PR DESCRIPTION
Corresponding to https://github.com/micro-manager/mmCoreAndDevices/pull/626.

Also removed specific versions for Windows SDK; the default/latest should be fine.